### PR TITLE
Automagically link the correct frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,13 @@ And then execute:
 $ bundle
 ```
 
-Put this in your RakeFile file:
-
-```ruby
-app.frameworks += ["SceneKit", "QuartzCore", "GLKit", "AVFoundation"]
-```
-
 ## Requires
 
 * Geomotion. You can use Geomotion's nice CATransform3D stuff
+
+## Uses Frameworks
+
+This gem will automatically link the following frameworks into your app: `SceneKit`, `QuartzCore`, `GLKit`, & `AVFoundation`
 
 ## Sample app
 

--- a/motion/motion-scene-kit.rb
+++ b/motion/motion-scene-kit.rb
@@ -7,4 +7,7 @@ end
 lib_dir_path = File.dirname(File.expand_path(__FILE__))
 Motion::Project::App.setup do |app|
   app.files.unshift(Dir.glob(File.join(lib_dir_path, "project/**/*.rb")))
+
+  # Require the frameworks the gem needs automatically.
+  app.frameworks += ['SceneKit', 'QuartzCore', 'GLKit', 'AVFoundation']
 end


### PR DESCRIPTION
So the user doesn't have to manage that themselves in their `Rakefile`.
